### PR TITLE
Remove references to examples/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ spacetime_lib:
 
 clean:
 	$(MAKE) -C src $@
-	$(MAKE) -C examples $@
 
 .PHONY: all spacetime_lib clean install uninstall reinstall
 
@@ -28,6 +27,3 @@ uninstall:
 reinstall:
 	-$(MAKE) uninstall
 	$(MAKE) install
-
-examples:
-	$(MAKE) -C examples


### PR DESCRIPTION
There is no `Makefile` in `examples/`, which creates an annoyance when running `make clean`.

The right way to solve this, of course, is to commit the missing `Makefile` :) I opened this PR because the issue tracker is disabled, and this is the crappy alternative solution.